### PR TITLE
Improvements to frontend

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,22 @@
+rules:
+  indent:
+    - 2
+    - 4
+  quotes:
+    - 2
+    - double
+  linebreak-style:
+    - 2
+    - unix
+  semi:
+    - 2
+    - never
+  no-use-before-define:
+    - 2
+    - nofunc
+  no-underscore-dangle:
+    - 0
+  no-process-exit:
+    - 0
+env:
+  node: true

--- a/Readme.md
+++ b/Readme.md
@@ -17,15 +17,37 @@ Run `npm -g install licensecheck`.
 Usage
 -----
 ```
-licensecheck [-m/--missing-only] [-h/--highlight regexp] [optional dir]
-
-    -m / --missing-only : only list licenses that are unspecified
-    -f / --flat : write flattened list of dependencies
-    --tsv : write flattened list of dependencies, tab-separated, wihtout coloring (suitable for parsing)
-    -h regexp / --highlight regexp : highlight licenses entries that match the regular expression (case insensitive)
-
+licensecheck [OPTIONS] [PATH]
+    -m, --missing-only       print only packages with missing license files.
+    -h ARG, --highlight=ARG  highlight licenses which match this regular
+                             expression.
+    -f, --flat               display without tree nesting.
+    --tsv                    short for --flat --separator="\t" --fields
+                             nameversion,license,licensefile.
+    --json                   emit JSON output.
+    --fields=ARG             Comma separated list of fields to display.
+                             Available fields include name, version,
+                             nameversion, license, licensefile,
+                             simplelicensefile as well as any top-level fields
+                             in the package.json file, such as "homepage".
+    -d ARG, --separator=ARG  separator between fields.
+    --help                   Display this help.
 ```
 
+Fields
+------
+
+The `--fields` flag can be used to control which fields are printed.  Valid
+fields include:
+
+- **`name`**: The name of the package, such as `markdown`
+- **`version`**: The version of the package, such as `0.5.0`
+- **`nameversion`**: The name and version, as an `@` separated tuple: `markdown@0.5.0`
+- **`license`**: The name of the license, with URL: `MIT (http://www.opensource.org/licenses/mit-license.php)`
+- **`licensefile`**: The path to the file used to determine the license: `node_modules/markdown/package.json`
+- **`simplelicensefile`**: The path to the file used to determine the license, with `node_modules` reduced to `~` as an abbreviation: `node_modules/chalk ~ strip-ansi ~ ansi-regex/package.json`
+
+Additionally, any toplevel field in the `package.json` file is available.  These include **`description`**, **`homepage`**, et cetera.
 
 Examples
 --------
@@ -49,13 +71,24 @@ nopt (2.1.2) ── MIT (https://github.com/isaacs/nopt/raw/master/LICENSE) ─�
 spdx-license-list (1.1.0) ── MIT License (https://spdx.org/licenses/MIT) ── node_modules/spdx-license-list/package.json
 treeify (1.0.1) ── MIT (http://lp.mit-license.org/) ── node_modules/treeify/package.json
 
-$ licensecheck --tsv | cut -f2 | sort -u
+$ licensecheck --tsv --fields license | sort -u
 MIT (http://lp.mit-license.org/)
 MIT (http://www.opensource.org/licenses/mit-license.php)
 MIT (https://github.com/isaacs/abbrev-js/raw/master/LICENSE)
 MIT (https://github.com/isaacs/nopt/raw/master/LICENSE)
 MIT License (https://spdx.org/licenses/MIT)
 zlib License (https://spdx.org/licenses/Zlib)
+
+$ licensecheck --json
+[ { name: 'abbrev',
+    version: '1.0.5',
+    license: 'MIT (https://github.com/isaacs/abbrev-js/raw/master/LICENSE)',
+    licensefile: 'node_modules/markdown/node_modules/nopt/node_modules/abbrev/package.json',
+    homepage: 'https://github.com/isaacs/abbrev-js',
+    description: 'Like ruby\'s abbrev module, but in js',
+    dependencies: '' },
+ ...
+]
 ```
 
 Overrides

--- a/cli.js
+++ b/cli.js
@@ -1,118 +1,249 @@
 // Based on code shamelessly lifted from https://github.com/shtylman/node-weaklink (with permission)
 
-var colors = require('colors')
-var treeify = require('treeify')
-var fs = require('fs')
-var stripJsonComments = require('strip-json-comments')
+"use strict"
 
-var licensecheck = require('./index.js')
+var chalk = require("chalk")
+var dashdash = require("dashdash")
+var treeify = require("treeify")
+var fs = require("fs")
+var stripJsonComments = require("strip-json-comments")
 
-var path = '.'
+var licensecheck = require("./index.js")
+
+var path = "."
 var overridesPath = "./licenses.json"
-var missingOnly = false
-var flat = false
-var format = 'color'
 var highlight = null
+var tsvFields = ["nameversion", "license", "licensefile"]
+var jsonFields = ["name", "version", "license", "licensefile", "homepage", "description", "dependencies"]
+var prettyFields = ["nameversion", "license", "simplelicensefile"]
+var allFields = ["name", "version", "nameversion", "license", "licensefile", "simplelicensefile"]
+var fields = null
+var sep = null
+var jsonOutputArray = []
 
-for (var i = 2; i < process.argv.length; i++) {
-    var arg = process.argv[i]
-    switch (arg) {
-        case '-m':
-        case '--missing-only':
-            missingOnly = true
-            break
-        case '-h':
-        case '--highlight':
-            highlight = new RegExp(process.argv[++i], 'i')
-            break
-        case '-f':
-        case '--flat':
-            flat = true
-            break
-        case '--tsv':
-            format = 'tsv'
-            flat = true
-            break
-        default:
-            path = arg
-            break
+var options = [
+    {
+        names: ["missing-only", "m"],
+        type: "bool",
+        help: "print only packages with missing license files",
+        default: false
+    },
+    {
+        names: ["highlight", "h"],
+        type: "string",
+        help: "highlight licenses which match this regular expression",
+        default: null
+    },
+    {
+        names: ["flat", "f"],
+        type: "bool",
+        help: "display without tree nesting",
+        default: false
+    },
+    {
+        names: ["tsv"],
+        type: "bool",
+        help: ("short for --flat --separator=\"\\t\" --fields " + tsvFields.join(",")),
+        default: false
+    },
+    {
+        names: ["json"],
+        type: "bool",
+        help: "emit JSON output",
+        default: false
+    },
+    {
+        names: ["fields"],
+        type: "string",
+        help: ("Comma separated list of fields to display.  Available " +
+              "fields include " + allFields.join(", ") + " as well as " +
+              "any top-level fields in the package.json file, such as " +
+              "\"homepage\"."),
+        default: null
+    },
+    {
+        names: ["separator", "d"],
+        type: "string",
+        help: "separator between fields",
+        default: " ── "
+    },
+    {
+        names: ["help"],
+        type: "bool",
+        help: "Display this help."
     }
+]
+
+var parser = dashdash.createParser({options: options})
+
+function usage() {
+    var help = parser.help()
+    console.error("usage: licensecheck [OPTIONS] [PATH]")
+    console.error(help)
+    process.exit(2)
+}
+
+try {
+    var opts = parser.parse(process.argv)
+} catch (e) {
+    console.error("error: " + e.message)
+    usage()
+}
+
+if (opts._args.length > 0) {
+    path = opts._args[0]
+}
+if (opts._args.length > 1) {
+    usage()
+}
+
+if (opts.help) {
+    usage()
+}
+
+if (opts.tsv) {
+    chalk.enabled = false
+    opts.flat = true
+    opts.separator = "\t"
+    fields = tsvFields
+}
+
+if (opts.json) {
+    chalk.enabled = false
+    opts.flat = true
+    fields = jsonFields
+}
+
+if (opts.fields) {
+    fields = opts.fields.split(",")
+}
+
+if (fields === null) {
+    fields = prettyFields
+}
+
+if (opts.separator) {
+    sep = opts.separator
+}
+sep = sep.replace(/\\t/g, "\t").replace(/\\n/g, "\n").replace(/\\0/g, "\0")
+
+if (opts.highlight) {
+    highlight = RegExp(opts.highlight, "i")
 }
 
 var overrides = fs.existsSync(overridesPath) &&
     JSON.parse(stripJsonComments(fs.readFileSync(overridesPath, "utf8"))) || {}
 
 
-if (flat) {
-    var dependencies = makeFlatDependencyMap(licensecheck(".", path, overrides))
-    Object.keys(dependencies).sort().forEach(function (key) {
-        console.log(dependencies[key])
-    })
-} else {
-    treeify.asLines(makeDependencyTree(licensecheck(".", path, overrides)), false, console.log)
+function main() {
+    var dependencies
+    if (opts.json) {
+        dependencies = makeFlatDependencyMap(licensecheck(".", path, overrides))
+        Object.keys(dependencies).sort().forEach(function (key) {
+            jsonOutputArray.push(dependencies[key])
+        })
+        console.log(jsonOutputArray)
+    } else if (opts.flat) {
+        dependencies = makeFlatDependencyMap(licensecheck(".", path, overrides))
+        Object.keys(dependencies).sort().forEach(function (key) {
+            console.log(dependencies[key])
+        })
+    } else {
+        treeify.asLines(makeDependencyTree(licensecheck(".", path, overrides)), false, console.log)
+    }
 }
 
+main()
 
 function isMissing(info) {
-    return !info.licenseFile || info.license === 'nomatch'
-}
-
-function simplifyFile(file) {
-    return file.replace(/\/node_modules\//g, ' ~ ')
+    return !info.licenseFile || info.license === "nomatch"
 }
 
 function getDescription(info) {
-    var key
-    var sep
     var file
-    if (format === 'color') {
-        sep = ' ── '
-        key = info.name + (" (" + info.version + ")").grey + sep
 
-        file = info.licenseFile
-        if (file) {
-            file = simplifyFile(file)
-            if (info.license === 'nomatch') {
-                key += ('unmatched license file: ' + file).yellow
-            } else if (highlight && highlight.test(info.license)) {
-                key += info.license.magenta + sep + file.grey
-            } else {
-                key += info.license.green + sep + file.grey
-            }
-        } else {
-            key += "no license found".red
+    var output = {}
+    fields.forEach(function fieldforeach(field) {
+        if (field === "name") {
+            output.name = info.name
+            return
         }
-    } else if (format === 'tsv') {
-        sep = '\t'
-        key = info.name + " (" + info.version + ")" + sep
+        if (field === "version") {
+            output.version = info.packageInfo.version
+            return
+        }
+        if (field === "nameversion") {
+            output.nameversion = info.name + "@" + info.packageInfo.version
+            return
+        }
+        if (field === "dependencies") {
+            output.dependencies = info.deps.map(function (dep) { return dep.name + "@" + dep.packageInfo.version }).join(",")
+            return
+        }
+        if (field === "license") {
+            file = info.licenseFile
+            if (file) {
+                if (info.license === "nomatch") {
+                    output.license = chalk.yellow("unmatched")
+                } else if (highlight && highlight.test(info.license)) {
+                    output.license = chalk.magenta(info.license)
+                } else {
+                    output.license = chalk.green(info.license)
+                }
+            } else {
+                output.license = chalk.red("unknown")
+            }
+            return
+        }
+        if (field === "licensefile" || field === "simplelicensefile") {
+            file = info.licenseFile
+            if (file) {
+                if (field === "simplelicensefile") {
+                    file = file.replace(/\/node_modules\//g, " ~ ")
+                }
+                if (info.license === "nomatch") {
+                    output.licensefile = chalk.yellow(file)
+                } else {
+                    output.licensefile = file
+                }
+            } else {
+                output.licensefile = chalk.red("no license found")
+            }
+            return
+        }
+        // A possible future enhancement is to support dot-delimited paths,
+        // such as author.name.  And/or to support attaching the full
+        // packaginfo.
+        if (typeof info.packageInfo[field] === "string") {
+            output[field] = info.packageInfo[field]
+            return
+        } else {
+            output[field] = "UNKNOWN"
+            return
+        }
+    })
 
-        file = info.licenseFile
-        if (file) {
-            if (info.license === 'nomatch') {
-                key += 'unmatched: ' + file + sep
-            } else {
-                key += info.license + sep + file
-            }
-        } else {
-            key += "MISSING" + sep
-        }
-    } else {
-        throw Error("invalid format: " + format)
+    if (opts.json) {
+        return output
     }
-    return key;
+    var outputArr = []
+    for (var f in output) {
+        outputArr.push(output[f])
+    }
+    return outputArr.join(sep)
 }
 
 
 function makeDependencyTree(info) {
-    if (missingOnly && !isMissing(info) && !info.deps.some(isMissing)) {
+    if (opts.missing_only && !isMissing(info) && !info.deps.some(isMissing)) {
         return {}
     }
-    var key = getDescription(info);
+    var key = getDescription(info)
     var tree = {}
     var dependencies = tree[key] = {}
     info.deps.map(makeDependencyTree).forEach(function (dependency) {
-        Object.keys(dependency).forEach(function (key) {
-            dependencies[key] = dependency[key]
+        Object.keys(dependency).forEach(function (k) {
+            dependencies[k] = dependency[k]
         })
     })
     return tree
@@ -120,8 +251,8 @@ function makeDependencyTree(info) {
 
 function makeFlatDependencyMap(info) {
     var map = {}
-    if (!missingOnly || isMissing(info)) {
-        map[info.name + '@' + info.version] = getDescription(info)
+    if (!opts.missing_only || isMissing(info)) {
+        map[info.name + "@" + info.packageInfo.version] = getDescription(info)
     }
     info.deps.forEach(function (dep) {
         var subMap = makeFlatDependencyMap(dep)

--- a/cli.js
+++ b/cli.js
@@ -142,7 +142,7 @@ function main() {
         Object.keys(dependencies).sort().forEach(function (key) {
             jsonOutputArray.push(dependencies[key])
         })
-        console.log(jsonOutputArray)
+        console.log(JSON.stringify(jsonOutputArray, null, "\t"))
     } else if (opts.flat) {
         dependencies = makeFlatDependencyMap(licensecheck(".", path, overrides))
         Object.keys(dependencies).sort().forEach(function (key) {

--- a/index.js
+++ b/index.js
@@ -98,6 +98,14 @@ function getJsonLicense(json) {
         if (typeof json === "string") {
             license = matchLicense(json) || "nomatch"
         } else {
+            // All of the below cases are for deprecated forms according to
+            // https://docs.npmjs.com/files/package.json
+
+            // Special case; seen only rarely, e.g. v8-debug@0.7.1
+            if (json.name && !json.type) {
+                json.type = json.name
+            }
+
             if (json.url && json.type) {
                 license = { name: json.type, url: json.url }
             } else if (json.type) {

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 // Original based on https://github.com/shtylman/node-weaklink (with permission)
 
-var fs = require('fs')
-var path = require('path')
-var markdown = require('markdown').markdown
-var spdxLicenses = require('spdx-license-list/spdx-full')
+"use strict"
 
-var licenseDir = __dirname + "/license-files/"
+var fs = require("fs")
+var path = require("path")
+var markdown = require("markdown").markdown
+var spdxLicenses = require("spdx-license-list/spdx-full")
+
+var licenseDir = path.join(__dirname, "license-files")
 
 // Alternate abbreviations used by package.json files.
 var licenseAliases = {
@@ -14,8 +16,10 @@ var licenseAliases = {
 }
 
 var licenses = []
+var licenseIndex = {}
+
 function normalizeText(text) {
-    return text.replace(/[^a-z0-9\s]/ig, '').toLowerCase().trim().split(/[\s\n]+/).join(' ')
+    return text.replace(/[^a-z0-9\s]/ig, "").toLowerCase().trim().split(/[\s\n]+/).join(" ")
 }
 
 // Match a license body or license id against known set of licenses.
@@ -27,7 +31,7 @@ function matchLicense(licenseString) {
     // Check matches of normalized license content against signatures.
     for (var i = 0; i < licenses.length; i++) {
         var license = licenses[i]
-        var match = false;
+        var match = false
         for (var j = 0; j < license.signatures.length; j++) {
             if (normalized.indexOf(license.signatures[j]) >= 0) {
                 match = true
@@ -44,7 +48,7 @@ function matchLicense(licenseString) {
         matchingLicenses.push(licenseIndex[licenseName] || {name: licenseName, id: null})
     }
     if (matchingLicenses.length === 0) {
-        return null;
+        return null
     }
     if (matchingLicenses.length > 1) {
         console.warn("Multiple matching licenses: " + matchingLicenses.length, [licenseString, matchingLicenses])
@@ -53,7 +57,6 @@ function matchLicense(licenseString) {
 }
 
 // Attach "id" field to each license, and add a lookup for accidental variations among SPDX license ids.
-var licenseIndex = {}
 Object.keys(spdxLicenses).forEach(function (key) {
     var license = spdxLicenses[key]
     license.id = key
@@ -74,7 +77,7 @@ fs.readdirSync(licenseDir).forEach(function (name) {
     // Add all variant signatures.
     var id = name.split(",")[0]
     if (licenseIndex[id]) {
-        licenseIndex[id].signatures.push(normalizeText(fs.readFileSync(licenseDir + name, "utf8")))
+        licenseIndex[id].signatures.push(normalizeText(fs.readFileSync(path.join(licenseDir, name), "utf8")))
     } else {
         console.warn("Unrecognized license for signature: " + name)
     }
@@ -84,9 +87,9 @@ fs.readdirSync(licenseDir).forEach(function (name) {
 // If a developer specifies just the name, we check it against SPDX, according to NPM guidelines.
 // If they supply a URL, we just link to it, preserving name and exact link.
 function getJsonLicense(json) {
-    var license = 'nomatch'
-    if (typeof json === 'string') {
-        license = matchLicense(json) || 'nomatch'
+    var license = "nomatch"
+    if (typeof json === "string") {
+        license = matchLicense(json) || "nomatch"
     } else {
         if (json.url) {
             license = { name: json.type, url: json.url }
@@ -99,7 +102,7 @@ function getJsonLicense(json) {
 
 function getFileLicense(filename) {
     var fileContents = fs.readFileSync(filename, "utf8")
-    return matchLicense(fileContents) || 'nomatch'
+    return matchLicense(fileContents) || "nomatch"
 }
 
 function getReadmeLicense(filename) {
@@ -119,7 +122,7 @@ function getReadmeLicense(filename) {
 function parseMarkdownLicense(markdownText) {
     var license = getMarkdownLicenseSection(markdownText)
     return license ?
-        (matchLicense(license) || 'nomatch')
+        (matchLicense(license) || "nomatch")
         : matchLicense(markdownText)
 }
 function getMarkdownLicenseSection(text) {
@@ -129,12 +132,12 @@ function getMarkdownLicenseSection(text) {
         var node = tree[i]
 
         // Find section with "License" in the name
-        if (node[0] === 'header' && /licen[cs]e/i.test(node[2])) {
+        if (node[0] === "header" && /licen[cs]e/i.test(node[2])) {
             var section = []
             // Group together all paragraph nodes immediately after the header
             for (var j = i + 1; j < tree.length; j++) {
                 var childNode = tree[j]
-                if (childNode[0] === 'para') {
+                if (childNode[0] === "para") {
                     section.push(childNode[1])
                 } else {
                     break
@@ -142,15 +145,15 @@ function getMarkdownLicenseSection(text) {
             }
             // If we got a license, return it
             if (section.length) {
-                return section.join('\n\n')
+                return section.join("\n\n")
             }
             // Otherwise consider using the header contents itself (e.g. "MIT License")
             if (/.+licen[cs]e/i.test(node[2])) {
                 return node[2]
             }
         }
-        // Check if paragraph has 'license' in it, and use it as-is
-        if (node[0] === 'para' && /.+licen[cs]e/i.test(node[1])) {
+        // Check if paragraph has "license" in it, and use it as-is
+        if (node[0] === "para" && /.+licen[cs]e/i.test(node[1])) {
             return node[1]
         }
     }
@@ -158,7 +161,7 @@ function getMarkdownLicenseSection(text) {
 }
 
 function formatLicense(license) {
-    if (typeof license === 'string') {
+    if (typeof license === "string") {
         return license
     } else if (license.name && license.url) {
         return license.name + " (" + license.url + ")"
@@ -176,7 +179,7 @@ module.exports = function checkPath(packageName, basePath, overrides) {
         return null
     }
 
-    var packageJsonPath = path.join(basePath, 'package.json')
+    var packageJsonPath = path.join(basePath, "package.json")
 
     var packageJson = JSON.parse(fs.readFileSync(packageJsonPath))
 
@@ -192,21 +195,21 @@ module.exports = function checkPath(packageName, basePath, overrides) {
         }
     }
 
-    var license = 'unknown'
+    var license = "unknown"
     var licenseFilePath
 
     // Check package.json for "license" or "licenses" fields
     if (packageJson.license || packageJson.licenses) {
         licenseFilePath = packageJsonPath
-        var licenses = packageJson.licenses || []
-        if (!Array.isArray(licenses)) {
+        var pkgLicenses = packageJson.licenses || []
+        if (!Array.isArray(pkgLicenses)) {
             // Bad JSON, using "licenses" not as an array
-            licenses = [licenses]
+            pkgLicenses = [pkgLicenses]
         }
         if (packageJson.license) {
-            licenses.push(packageJson.license)
+            pkgLicenses.push(packageJson.license)
         }
-        license = licenses.map(getJsonLicense).map(formatLicense).join(', ')
+        license = pkgLicenses.map(getJsonLicense).map(formatLicense).join(", ")
     } else {
         // Look for file with "license" or "copying" in its name
         var files = fs.readdirSync(basePath)
@@ -231,7 +234,7 @@ module.exports = function checkPath(packageName, basePath, overrides) {
                         if (result) {
                             license = formatLicense(result)
                             licenseFilePath = file
-                            return license !== 'nomatch'
+                            return license !== "nomatch"
                         }
                     }
                 }
@@ -244,7 +247,7 @@ module.exports = function checkPath(packageName, basePath, overrides) {
     var dependencies = []
 
     Object.keys(packageJson.dependencies || {}).sort().forEach(function (name) {
-        var res = checkPath(name, path.join(basePath, 'node_modules', name), overrides)
+        var res = checkPath(name, path.join(basePath, "node_modules", name), overrides)
         if (res) {
             res.name = name
             res.deps = res.deps || []
@@ -254,9 +257,9 @@ module.exports = function checkPath(packageName, basePath, overrides) {
 
     return {
         name: packageJson.name,
-        version: packageJson.version,
         license: license,
         licenseFile: licenseFilePath,
-        deps: dependencies
+        deps: dependencies,
+        packageInfo: packageJson
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,17 +13,19 @@
         "url": "http://marcello.cellosoft.com/"
     },
     "dependencies": {
-        "colors": "0.6.2",
+        "chalk": "1.0.0",
+        "dashdash": "1.10.0",
         "markdown": "0.5.0",
         "treeify": "1.0.1",
         "spdx-license-list": "1.1.0",
         "strip-json-comments": "1.0.1"
     },
     "devDependencies": {
+        "eslint" :"0.21.2",
         "mocha":"1.18.2"
     },
     "scripts": {
-        "test":"./node_modules/.bin/mocha"
+        "test":"./node_modules/.bin/eslint *.js && ./node_modules/.bin/mocha"
     },
     "license": "zlib",
     "bin": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "scripts": {
         "test":"./node_modules/.bin/eslint *.js && ./node_modules/.bin/mocha"
     },
-    "license": "zlib",
+    "license": "Zlib",
     "bin": {
         "licensecheck": "./bin/licensecheck"
     }

--- a/test/simple.js
+++ b/test/simple.js
@@ -18,12 +18,13 @@ test('licensecheck self', function () {
 
     testResult(result, "licensecheck", "zlib License (https://spdx.org/licenses/Zlib)", "package.json")
 
-    assert.equal(5, result.deps.length)
-    testResult(result.deps[0], "colors", "MIT License (https://spdx.org/licenses/MIT)", "MIT-LICENSE.txt")
-    testResult(result.deps[1], "markdown", "MIT (http://www.opensource.org/licenses/mit-license.php)", "package.json")
-    testResult(result.deps[2], "spdx-license-list", "MIT License (https://spdx.org/licenses/MIT)", "package.json")
-    testResult(result.deps[3], "strip-json-comments", "MIT License (https://spdx.org/licenses/MIT)", "package.json")
-    testResult(result.deps[4], "treeify", "MIT (http://lp.mit-license.org/)", "package.json")
+    assert.equal(6, result.deps.length)
+    testResult(result.deps[0], "chalk", "MIT License (https://spdx.org/licenses/MIT)", "package.json")
+    testResult(result.deps[1], "dashdash", "MIT License (https://spdx.org/licenses/MIT)", "LICENSE.txt")
+    testResult(result.deps[2], "markdown", "MIT (http://www.opensource.org/licenses/mit-license.php)", "package.json")
+    testResult(result.deps[3], "spdx-license-list", "MIT License (https://spdx.org/licenses/MIT)", "package.json")
+    testResult(result.deps[4], "strip-json-comments", "MIT License (https://spdx.org/licenses/MIT)", "package.json")
+    testResult(result.deps[5], "treeify", "MIT (http://lp.mit-license.org/)", "package.json")
 })
 
 test('licensecheck mochajs', function () {
@@ -34,7 +35,7 @@ test('licensecheck mochajs', function () {
     assert.equal(7, result.deps.length)
 
     testResult(result.deps[0], "commander", "MIT License (https://spdx.org/licenses/MIT)", "Readme.md")
-    testResult(result.deps[1], "debug", "MIT License (https://spdx.org/licenses/MIT)", "Readme.md")
+    testResult(result.deps[1], "debug", "MIT License (https://spdx.org/licenses/MIT)", "package.json")
     testResult(result.deps[2], "diff", "BSD (http://github.com/kpdecker/jsdiff/blob/master/LICENSE)", "package.json")
     testResult(result.deps[3], "glob", 'BSD 2-clause "Simplified" License (https://spdx.org/licenses/BSD-2-Clause)', "package.json")
     testResult(result.deps[4], "growl", "MIT License (https://spdx.org/licenses/MIT)", "Readme.md")


### PR DESCRIPTION
add --fields to select output fields
add --json outputter
add --separator
add --help
switch from 'colors' to 'chalk' (allows easy disabling of colors)
improve CLI parsing
add eslint checking

I realize this might be a lot to swallow.  Some of the 'cosmetic' changes like ';' and quotes are to please
eslint.  I'm a terrible javascript programmer, so eslint helps me not make stupid mistakes.