### PR TITLE
Better matching of licenses by name.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ var path = require('path')
 var markdown = require('markdown').markdown
 var spdxLicenses = require('spdx-license-list/spdx-full')
 
+var normalizeText = require('./normtext')
+
 var licenseDir = __dirname + "/license-files/"
 
 // Alternate abbreviations used by package.json files.
@@ -15,11 +17,6 @@ var licenseAliases = {
 }
 
 var licenses = []
-function normalizeText(text) {
-    // Normalize text for matching purposes.
-    // Consider "-" same as space: Apache-2.0 -> apache 20, Apache 2.0 -> apache 20
-    return text.replace(/[^a-z0-9\s-]/ig, '').toLowerCase().trim().split(/[\s\n-]+/).join(' ')
-}
 
 // Match a license body or license id against known set of licenses.
 function matchLicense(licenseString) {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ function matchLicense(licenseString) {
     // For single-line license, check if it's a known license id.
     if (matchingLicenses.length === 0 && !/[\n\f\r]/.test(licenseString) && licenseString.length < 100) {
         var licenseName = normalizeText(licenseString)
-        var license = licenseIndex[licenseName]
+        // If there's an extra "license" on the end of the name, drop it ("MIT License" -> "MIT").
+        var license = licenseIndex[licenseName] || licenseIndex[licenseName.replace(/ licen[sc]e$/, "")]
         if (!license) {
           license = {name: licenseName, id: null}
           console.warn("Non-matched license name: " + licenseName)

--- a/normtext.js
+++ b/normtext.js
@@ -1,0 +1,10 @@
+/**
+ * Normalize text for matching purposes.
+ * Preserve only alphanumeric words and periods inside words.
+ * "UIUC/NCSA " -> "uiuc ncsa"
+ * "Apache-2.0" and "Apache 2.0" -> "apache 2.0"
+ * "MIT License." -> "mit license"
+ */
+module.exports = function(text) {
+    return text.toLowerCase().match(/[a-z0-9]([a-z0-9.]*[a-z0-9])?/ig).join(' ')
+}

--- a/test/simple.js
+++ b/test/simple.js
@@ -34,7 +34,7 @@ test('licensecheck mochajs', function () {
     assert.equal(7, result.deps.length)
 
     testResult(result.deps[0], "commander", "MIT License (https://spdx.org/licenses/MIT)", "Readme.md")
-    testResult(result.deps[1], "debug", "MIT License (https://spdx.org/licenses/MIT)", "Readme.md")
+    testResult(result.deps[1], "debug", "MIT License (https://spdx.org/licenses/MIT)", "package.json")
     testResult(result.deps[2], "diff", "BSD (http://github.com/kpdecker/jsdiff/blob/master/LICENSE)", "package.json")
     testResult(result.deps[3], "glob", 'BSD 2-clause "Simplified" License (https://spdx.org/licenses/BSD-2-Clause)', "package.json")
     testResult(result.deps[4], "growl", "MIT License (https://spdx.org/licenses/MIT)", "Readme.md")

--- a/test/simple.js
+++ b/test/simple.js
@@ -2,6 +2,7 @@ var assert = require('assert')
 var path = require('path')
 
 var licensecheck = require('../index.js')
+var normalizeText = require('../normtext.js')
 
 suite('Simple')
 
@@ -41,4 +42,11 @@ test('licensecheck mochajs', function () {
     testResult(result.deps[5], "jade", "MIT License (https://spdx.org/licenses/MIT)", "LICENSE")
     testResult(result.deps[6], "mkdirp", "MIT License (https://spdx.org/licenses/MIT)", "package.json")
 
+})
+
+test('normalizeText', function() {
+    assert.equal(
+      'my hybrid ambiguous made up uiuc ncsa apache 2.0 or apache 2.0 license',
+      normalizeText(' My hybrid,  (ambiguous!) made-up UIUC/NCSA Apache 2.0 (or Apache-2.0) license.')
+    )
 })


### PR DESCRIPTION
Match license names based on normalized text.
Warn about non-matched license names.
Handle Apache-2.0 vs Apache 2.0, handle "Apache version 2.0" etc.
Update tests.