### PR TITLE
Fixes #9 support opensource.org and spdx.org license urls

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -85,7 +85,9 @@ function getDescription(info) {
         file = info.licenseFile
         if (file) {
             file = simplifyFile(file)
-            if (info.license === 'nomatch') {
+            if (info.license.startsWith('unknown')) {
+                key += info.license.yellow
+            } else if (info.license === 'nomatch') {
                 key += ('unmatched license file: ' + file).yellow
             } else if (highlight && highlight.test(info.license)) {
                 key += info.license.magenta + sep + file.grey
@@ -101,7 +103,9 @@ function getDescription(info) {
 
         file = info.licenseFile
         if (file) {
-            if (info.license === 'nomatch') {
+            if (info.license.startsWith('unknown')) {
+                key += info.license.yellow
+            } else if (info.license === 'nomatch') {
                 key += 'unmatched: ' + file + sep
             } else {
                 key += info.license + sep + file

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ var normalizeText = require('./normtext')
 
 var licenseDir = __dirname + "/license-files/"
 
+var urltoLicense = require('./urltolicense')
+
 // Alternate abbreviations used by package.json files.
 var licenseAliases = {
     "BSD": "BSD-2-Clause",
@@ -172,7 +174,14 @@ function formatLicense(license) {
         return license.name + " (" + "https://spdx.org/licenses/" + license.id + ")"
     } else if (license.name) {
         return license.name
-    } else {
+    } else if (license.url) {
+        var licensename = urltoLicense(license.url)
+        if (licensename)
+          return licensename + " (" + license.url + ")"
+        else
+          throw Error("unknown license: " + JSON.stringify(license))
+    }
+    else {
         throw Error("unknown license: " + JSON.stringify(license))
     }
 }

--- a/index.js
+++ b/index.js
@@ -179,10 +179,10 @@ function formatLicense(license) {
         if (licensename)
           return licensename + " (" + license.url + ")"
         else
-          throw Error("unknown license: " + JSON.stringify(license))
+          return "unknown"+ " (" + license.url + ")"
     }
     else {
-        throw Error("unknown license: " + JSON.stringify(license))
+        return "unknown license"
     }
 }
 

--- a/test/simple.js
+++ b/test/simple.js
@@ -74,8 +74,8 @@ test('urltolicense', function() {
   assert.equal("Zlib", urltolicense("https://opensource.org/licenses/Zlib"))
   assert.equal("BSD-3-Clause", urltolicense("www.opensource.org/licenses/BSD-3-Clause"))
   assert.equal("ISC", urltolicense("opensource.org/licenses/ISC"))
-  assert.equal("MIT", urltolicense("http://www.opensource.org/licenses/mit-license.php"))
-  assert.equal("LGPL", urltolicense("http://www.opensource.org/licenses/lgpl-license"))
+  assert.equal("mit", urltolicense("http://www.opensource.org/licenses/mit-license.php"))
+  assert.equal("lgpl", urltolicense("http://www.opensource.org/licenses/lgpl-license"))
 
   assert.equal("Apache-2.0", urltolicense("http://spdx.org/licenses/Apache-2.0.html"))
   assert.equal("Apache-2.0", urltolicense("https://spdx.org/licenses/Apache-2.0.html"))

--- a/test/simple.js
+++ b/test/simple.js
@@ -3,6 +3,7 @@ var path = require('path')
 
 var licensecheck = require('../index.js')
 var normalizeText = require('../normtext.js')
+var urltolicense = require('../urltolicense')
 
 suite('Simple')
 
@@ -64,4 +65,15 @@ test('normalizeText', function() {
       'my hybrid ambiguous made up uiuc ncsa apache 2.0 or apache 2.0 license',
       normalizeText(' My hybrid,  (ambiguous!) made-up UIUC/NCSA Apache 2.0 (or Apache-2.0) license.')
     )
+})
+
+test('urltolicense', function() {
+  assert.equal("MIT", urltolicense("http://www.opensource.org/licenses/MIT"))
+  assert.equal("APACHE-2.0", urltolicense("http://opensource.org/licenses/APACHE-2.0"))
+  assert.equal("EPL-1.0", urltolicense("https://www.opensource.org/licenses/EPL-1.0"))
+  assert.equal("Zlib", urltolicense("https://opensource.org/licenses/Zlib"))
+  assert.equal("BSD-3-Clause", urltolicense("www.opensource.org/licenses/BSD-3-Clause"))
+  assert.equal("ISC", urltolicense("opensource.org/licenses/ISC"))
+  assert.equal("MIT", urltolicense("http://www.opensource.org/licenses/mit-license.php"))
+  assert.equal("LGPL", urltolicense("http://www.opensource.org/licenses/lgpl-license"))
 })

--- a/test/simple.js
+++ b/test/simple.js
@@ -76,4 +76,10 @@ test('urltolicense', function() {
   assert.equal("ISC", urltolicense("opensource.org/licenses/ISC"))
   assert.equal("MIT", urltolicense("http://www.opensource.org/licenses/mit-license.php"))
   assert.equal("LGPL", urltolicense("http://www.opensource.org/licenses/lgpl-license"))
+
+  assert.equal("Apache-2.0", urltolicense("http://spdx.org/licenses/Apache-2.0.html"))
+  assert.equal("Apache-2.0", urltolicense("https://spdx.org/licenses/Apache-2.0.html"))
+  assert.equal("MIT", urltolicense("http://www.spdx.org/licenses/MIT.html"))
+  assert.equal("MIT", urltolicense("https://www.spdx.org/licenses/MIT.html"))
+  assert.equal("Apache-2.0", urltolicense("https://www.spdx.org/licenses/Apache-2.0"))
 })

--- a/urltolicense.js
+++ b/urltolicense.js
@@ -2,37 +2,35 @@
  * Find license name from license url
  */
 
-var urls = {
-  "https://opensource.org/licenses/Apache-2.0"  : "Apache-2.0",
-  "https://opensource.org/licenses/BSD-3-Clause": "BSD-3-Clause",
-  "https://opensource.org/licenses/BSD-2-Clause": "BSD-2-Clause",
-  "https://opensource.org/licenses/MIT"         : "MIT",
-  "https://opensource.org/licenses/GPL-2.0"     : "GPL-2.0",
-  "https://opensource.org/licenses/GPL-3.0"     : "GPL-3.0",
-  "https://opensource.org/licenses/LGPL-2.1"    : "LGPL-2.1",
-  "https://opensource.org/licenses/LGPL-3.0"    : "LGPL-3.0",
-  "https://opensource.org/licenses/MPL-2.0"     : "MPL-2.0",
-  "https://opensource.org/licenses/CDDL-1.0"    : "CDDL-1.0",
-  "https://opensource.org/licenses/EPL-1.0"     : "EPL-1.0",
-  "http://opensource.org/licenses/Apache-2.0"  : "Apache-2.0",
-  "http://opensource.org/licenses/BSD-3-Clause": "BSD-3-Clause",
-  "http://opensource.org/licenses/BSD-2-Clause": "BSD-2-Clause",
-  "http://opensource.org/licenses/mit-license.php" : "MIT",
-  "http://opensource.org/licenses/MIT"         : "MIT",
-  "http://opensource.org/licenses/GPL-2.0"     : "GPL-2.0",
-  "http://opensource.org/licenses/GPL-3.0"     : "GPL-3.0",
-  "http://opensource.org/licenses/LGPL-2.1"    : "LGPL-2.1",
-  "http://opensource.org/licenses/LGPL-3.0"    : "LGPL-3.0",
-  "http://opensource.org/licenses/MPL-2.0"     : "MPL-2.0",
-  "http://opensource.org/licenses/CDDL-1.0"    : "CDDL-1.0",
-  "http://opensource.org/licenses/EPL-1.0"     : "EPL-1.0",
-  "http://www.opensource.org/licenses/mit-license.php" : "MIT",
-  "https://www.opensource.org/licenses/mit-license.php" : "MIT"
+// Check if url is an opensource.org license url
+function isopensourceorgLicense(url) {
+  var re = /(http(s)?\:\/\/)?(www.)?opensource.org\/licenses\/([A-Za-z0-9]|[\-\.\_])+$/
+  return url.match(re)
 }
 
-module.exports = function (url) {
-  if (url in urls)
-    return urls[url];
+// Find and return license name from opensource.org url
+function getopensourceorgLicense(url) {
+  var licensenames = {
+    "mit-license.php": "MIT",
+    "gpl-license": "GPL",
+    "lgpl-license": "LGPL"
+  }
+
+  var array = url.split("/");
+  var license = array[array.length - 1];
+
+  if (license in licensenames)
+    return licensenames[license];
   else
-    return false;
+    return license;
+}
+
+// Find license name from
+module.exports = function (url) {
+
+  if (isopensourceorgLicense(url))
+    return getopensourceorgLicense(url);
+
+  else
+    return "unknown"
 }

--- a/urltolicense.js
+++ b/urltolicense.js
@@ -1,0 +1,38 @@
+/**
+ * Find license name from license url
+ */
+
+var urls = {
+  "https://opensource.org/licenses/Apache-2.0"  : "Apache-2.0",
+  "https://opensource.org/licenses/BSD-3-Clause": "BSD-3-Clause",
+  "https://opensource.org/licenses/BSD-2-Clause": "BSD-2-Clause",
+  "https://opensource.org/licenses/MIT"         : "MIT",
+  "https://opensource.org/licenses/GPL-2.0"     : "GPL-2.0",
+  "https://opensource.org/licenses/GPL-3.0"     : "GPL-3.0",
+  "https://opensource.org/licenses/LGPL-2.1"    : "LGPL-2.1",
+  "https://opensource.org/licenses/LGPL-3.0"    : "LGPL-3.0",
+  "https://opensource.org/licenses/MPL-2.0"     : "MPL-2.0",
+  "https://opensource.org/licenses/CDDL-1.0"    : "CDDL-1.0",
+  "https://opensource.org/licenses/EPL-1.0"     : "EPL-1.0",
+  "http://opensource.org/licenses/Apache-2.0"  : "Apache-2.0",
+  "http://opensource.org/licenses/BSD-3-Clause": "BSD-3-Clause",
+  "http://opensource.org/licenses/BSD-2-Clause": "BSD-2-Clause",
+  "http://opensource.org/licenses/mit-license.php" : "MIT",
+  "http://opensource.org/licenses/MIT"         : "MIT",
+  "http://opensource.org/licenses/GPL-2.0"     : "GPL-2.0",
+  "http://opensource.org/licenses/GPL-3.0"     : "GPL-3.0",
+  "http://opensource.org/licenses/LGPL-2.1"    : "LGPL-2.1",
+  "http://opensource.org/licenses/LGPL-3.0"    : "LGPL-3.0",
+  "http://opensource.org/licenses/MPL-2.0"     : "MPL-2.0",
+  "http://opensource.org/licenses/CDDL-1.0"    : "CDDL-1.0",
+  "http://opensource.org/licenses/EPL-1.0"     : "EPL-1.0",
+  "http://www.opensource.org/licenses/mit-license.php" : "MIT",
+  "https://www.opensource.org/licenses/mit-license.php" : "MIT"
+}
+
+module.exports = function (url) {
+  if (url in urls)
+    return urls[url];
+  else
+    return false;
+}

--- a/urltolicense.js
+++ b/urltolicense.js
@@ -2,50 +2,31 @@
  * Find license name from license url
  */
 
-// Check if url is an opensource.org license url
-function isopensourceorgLicense(url) {
-  var re = /(http(s)?\:\/\/)?(www.)?opensource.org\/licenses\/([A-Za-z0-9]|[\-\.\_])+$/
-  return url.match(re)
-}
+function getLicenseFromUrl(url) {
+    var regex = {
+        opensource: /(http(s)?\:\/\/)?(www.)?opensource.org\/licenses\/([A-Za-z0-9\-\.\_]+)$/,
+        spdx: /(http(s)?\:\/\/)?(www.)?spdx.org\/licenses\/([A-Za-z0-9\-\.\_]+)$/
+    }
 
-// Find and return license name from opensource.org url
-function getopensourceorgLicense(url) {
-  var licensenames = {
-    "mit-license.php": "MIT",
-    "gpl-license"    : "GPL",
-    "lgpl-license"   : "LGPL"
-  }
-  var array = url.split("/");
-  var license = array[array.length - 1];
+    for (re in regex) {
+        var tokens = url.match(regex[re])
 
-  if (license in licensenames)
-    return licensenames[license];
-  else
-    return license;
-}
+        if (tokens) {
+            var license = tokens[tokens.length - 1]
 
-// Check if url is an spdx.org license url
-function isspdxLicense(url) {
-  re = /(http(s)?\:\/\/)?(www.)?spdx.org\/licenses\/[A-Za-z0-9]|[\-\.\_]\.html$/
-  return url.match(re)
-}
+            // remove .html, .php, etc. from license name
+            var extensions = ['.html', '.php', '-license']
+            for (i in extensions) {
+                if (license.slice(-extensions[i].length) === extensions[i]) {
+                    license = license.slice(0, -extensions[i].length)
+                }
+            }
 
-// Find and return license name from spdx.org url
-function getspdxLicense(url) {
-  var array = url.split("/")
-  var license = array[array.length - 1]
+            return license
+        }
+    }
 
-  if (license.substr(-5) === ".html")
-    license = license.substr(0, license.length - 5)
-  return license;
-}
-
-// Find license name from
-module.exports = function (url) {
-  if (isopensourceorgLicense(url))
-    return getopensourceorgLicense(url);
-  if (isspdxLicense(url))
-    return getspdxLicense(url);
-  else
     return false
 }
+
+module.exports = getLicenseFromUrl

--- a/urltolicense.js
+++ b/urltolicense.js
@@ -47,5 +47,5 @@ module.exports = function (url) {
   if (isspdxLicense(url))
     return getspdxLicense(url);
   else
-    return "unknown"
+    return false
 }

--- a/urltolicense.js
+++ b/urltolicense.js
@@ -12,10 +12,9 @@ function isopensourceorgLicense(url) {
 function getopensourceorgLicense(url) {
   var licensenames = {
     "mit-license.php": "MIT",
-    "gpl-license": "GPL",
-    "lgpl-license": "LGPL"
+    "gpl-license"    : "GPL",
+    "lgpl-license"   : "LGPL"
   }
-
   var array = url.split("/");
   var license = array[array.length - 1];
 
@@ -25,12 +24,28 @@ function getopensourceorgLicense(url) {
     return license;
 }
 
+// Check if url is an spdx.org license url
+function isspdxLicense(url) {
+  re = /(http(s)?\:\/\/)?(www.)?spdx.org\/licenses\/[A-Za-z0-9]|[\-\.\_]\.html$/
+  return url.match(re)
+}
+
+// Find and return license name from spdx.org url
+function getspdxLicense(url) {
+  var array = url.split("/")
+  var license = array[array.length - 1]
+
+  if (license.substr(-5) === ".html")
+    license = license.substr(0, license.length - 5)
+  return license;
+}
+
 // Find license name from
 module.exports = function (url) {
-
   if (isopensourceorgLicense(url))
     return getopensourceorgLicense(url);
-
+  if (isspdxLicense(url))
+    return getspdxLicense(url);
   else
     return "unknown"
 }


### PR DESCRIPTION
Added support for opensource.org and spdx.org license urls for fixing #9 .
Unknown licenses are specified as "unknown" instead of throwing error.