### PR TITLE
Support NPM3 modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -188,7 +188,15 @@ function formatLicense(license) {
 
 module.exports = function checkPath(packageName, basePath, overrides, includeDevDependencies, includeOptDependencies) {
     if (!fs.existsSync(basePath)) {
-        return null
+        var dirs = basePath.split(path.sep)
+        if (dirs.length > 2) {
+            // Instead, search for the module in the parent node_modules folder
+            var moduleDirs = dirs.slice(dirs.length - 2, dirs.length)
+            var baseDirs = dirs.slice(0, dirs.length - 4)
+            return checkPath(packageName, baseDirs.concat(moduleDirs).join(path.sep), overrides);
+        } else {
+            return null
+        }
     }
 
     var packageJsonPath = path.join(basePath, 'package.json')


### PR DESCRIPTION
I added support for NPM3 module layout. If a module is not found, it splices out the last-but-one module path.

For example, if the module is not found when searching in `node_modules\concat-stream\node_modules\readable-stream\node_modules\inherits`, it will next search in `node_modules\concat-stream\node_modules\inherits`, and so on until the path cannot be shrunk any more.