### PR TITLE
Handle invalid package.json where license property is an array

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ module.exports = function checkPath(packageName, basePath, overrides, includeDev
         }
         if (Array.isArray(packageJson.license)) {
             // Bad JSON, using "license" as an array
-            licenses = packageJson.license
+            licenses = licenses.concat(packageJson.license)
         } else if (packageJson.license) {
             licenses.push(packageJson.license)
         }

--- a/index.js
+++ b/index.js
@@ -218,7 +218,10 @@ module.exports = function checkPath(packageName, basePath, overrides, includeDev
             // Bad JSON, using "licenses" not as an array
             licenses = [licenses]
         }
-        if (packageJson.license) {
+        if (Array.isArray(packageJson.license)) {
+            // Bad JSON, using "license" as an array
+            licenses = packageJson.license
+        } else if (packageJson.license) {
             licenses.push(packageJson.license)
         }
         license = licenses.map(getJsonLicense).map(formatLicense).join(', ')


### PR DESCRIPTION
This package was causing errors because it illegally sets the `license` property to an array: https://github.com/dominictarr/pause-stream/blob/master/package.json