### PR TITLE
Added an option to write each dependency only once

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,10 +21,11 @@ licensecheck [-m/--missing-only] [-h/--highlight regexp] [optional dir]
 
     -m / --missing-only : only list licenses that are unspecified
     -f / --flat : write flattened list of dependencies
-    --tsv : write flattened list of dependencies, tab-separated, wihtout coloring (suitable for parsing)
+    --tsv : write flattened list of dependencies, tab-separated, without coloring (suitable for parsing)
     -h regexp / --highlight regexp : highlight licenses entries that match the regular expression (case insensitive)
-    --dev : Include development dependencies
-    --opt : Include optional dependencies
+    --dev : include development dependencies
+    --opt : include optional dependencies
+    --once : write each dependency only once, even if it appears in several places in the dependency tree
 
 ```
 

--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,8 @@ var format = 'color'
 var highlight = null
 var includeDevDependencies = false
 var includeOptDependencies = false
+var once = false
+var seen = {}
 
 for (var i = 2; i < process.argv.length; i++) {
     var arg = process.argv[i]
@@ -40,6 +42,10 @@ for (var i = 2; i < process.argv.length; i++) {
         case '--tsv':
             format = 'tsv'
             flat = true
+            break
+        case '-o':
+        case '--once':
+            once = true
             break
         default:
             path = arg
@@ -140,6 +146,10 @@ function makeFlatDependencyMap(info) {
     if (!missingOnly || isMissing(info)) {
         map[info.name + '@' + info.version] = getDescription(info)
     }
+    if (once && seen[info.name + '@' + info.version]) {
+        return {}
+    }
+    seen[info.name + '@' + info.version] = true
     info.deps.forEach(function (dep) {
         var subMap = makeFlatDependencyMap(dep)
         Object.keys(subMap).forEach(function (key) {


### PR DESCRIPTION
I added a new command line option to make the tool print each dependency only once. Often a commonly-used library will be included by many other libraries in my project, and this makes it harder to build a unique list of third-party libraries.