### PR TITLE
Expose raw license details

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,6 +225,7 @@ module.exports = function checkPath (packageName, basePath, overrides, includeDe
     }
   }
 
+  var licensesRaw = []
   var license = 'unknown'
   var licenseFilePath
 
@@ -242,7 +243,8 @@ module.exports = function checkPath (packageName, basePath, overrides, includeDe
     } else if (packageJson.license) {
       licenses.push(packageJson.license)
     }
-    license = licenses.map(getJsonLicense).map(formatLicense).join(', ')
+    licensesRaw = licenses.map(getJsonLicense)
+    license = licensesRaw.map(formatLicense).join(', ')
   } else {
     // Look for file with "license" or "copying" in its name
     var files = fs.readdirSync(basePath)
@@ -250,7 +252,8 @@ module.exports = function checkPath (packageName, basePath, overrides, includeDe
       if (/licen[sc]e/i.test(name) || /copying.*/i.test(name)) {
         var file = path.join(basePath, name)
         if (fs.statSync(file).isFile()) {
-          license = formatLicense(getFileLicense(file))
+          licensesRaw = [getFileLicense(file)]
+          license = formatLicense(licensesRaw[0])
           licenseFilePath = file
           return true
         }
@@ -265,6 +268,7 @@ module.exports = function checkPath (packageName, basePath, overrides, includeDe
           if (fs.statSync(file).isFile()) {
             var result = getReadmeLicense(file)
             if (result) {
+              licensesRaw = [result]
               license = formatLicense(result)
               licenseFilePath = file
               return license !== 'nomatch'
@@ -303,6 +307,7 @@ module.exports = function checkPath (packageName, basePath, overrides, includeDe
     name: packageJson.name,
     version: packageJson.version,
     license: license,
+    licensesRaw: licensesRaw,
     licenseFile: licenseFilePath && path.relative(process.cwd(), licenseFilePath),
     deps: dependencies.sort(function (dep1, dep2) { return dep1.name.localeCompare(dep2.name) })
   }

--- a/test/licensecheck.js
+++ b/test/licensecheck.js
@@ -9,6 +9,7 @@ suite('licensecheck')
 
 function replacer (key, value) {
   switch (key) {
+    case 'licensesRaw':
     case 'licenseFile':
     case 'version':
       return undefined


### PR DESCRIPTION
This is a great tool, thank you!

I'm writing a wrapper around node-licensecheck to add some business rules (whitelisting). Unfortunately, the raw details of the licenses aren't exposed, only the stringified form, which is pretty difficult to cleanly parse in its most general form (multiple licenses, multiple URLs).

It seems reasonable to expose those so that the code can be reused without trying to parse the stringified versions of the licenses.